### PR TITLE
Category domain and started create category use case

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -12,6 +12,7 @@ repositories {
 dependencies {
     implementation(project(":domain"))
     testImplementation platform('org.junit:junit-bom:5.10.0')
+    testImplementation "org.mockito:mockito-junit-jupiter:5.18.0"
     testImplementation 'org.junit.jupiter:junit-jupiter'
 }
 

--- a/application/src/main/java/com/sollaris/admin/catalogo/application/NullaryUseCase.java
+++ b/application/src/main/java/com/sollaris/admin/catalogo/application/NullaryUseCase.java
@@ -1,0 +1,5 @@
+package com.sollaris.admin.catalogo.application;
+
+public abstract class NullaryUseCase<OUT> {
+    public abstract void execute();
+}

--- a/application/src/main/java/com/sollaris/admin/catalogo/application/UnitUseCase.java
+++ b/application/src/main/java/com/sollaris/admin/catalogo/application/UnitUseCase.java
@@ -1,0 +1,5 @@
+package com.sollaris.admin.catalogo.application;
+
+public abstract class UnitUseCase {
+    public abstract void execute(IN anIn);
+}

--- a/application/src/main/java/com/sollaris/admin/catalogo/application/UseCase.java
+++ b/application/src/main/java/com/sollaris/admin/catalogo/application/UseCase.java
@@ -3,8 +3,8 @@ package com.sollaris.admin.catalogo.application;
 
 import com.sollaris.admin.catalogo.domain.category.Category;
 
-public class UseCase {
-    public Category execute() {
-        return new Category();
-    }
+public abstract class UseCase<IN, OUT> {
+    public abstract OUT execute(IN anIn);
+
+
 }

--- a/application/src/main/java/com/sollaris/admin/catalogo/application/category/create/CreateCategoryCommand.java
+++ b/application/src/main/java/com/sollaris/admin/catalogo/application/category/create/CreateCategoryCommand.java
@@ -1,0 +1,20 @@
+package com.sollaris.admin.catalogo.application.category.create;
+
+public record CreateCategoryCommand(
+        String name,
+        String description,
+        boolean isActive
+) {
+
+    public static CreateCategoryCommand with(
+            final String aName,
+            final String aDescription,
+            final boolean isActive
+    ) {
+        return new CreateCategoryCommand(
+                aName,
+                aDescription,
+                isActive
+        );
+    }
+}

--- a/application/src/main/java/com/sollaris/admin/catalogo/application/category/create/CreateCategoryOutput.java
+++ b/application/src/main/java/com/sollaris/admin/catalogo/application/category/create/CreateCategoryOutput.java
@@ -1,0 +1,14 @@
+package com.sollaris.admin.catalogo.application.category.create;
+
+import com.sollaris.admin.catalogo.domain.category.Category;
+import com.sollaris.admin.catalogo.domain.category.CategoryID;
+
+public record CreateCategoryOutput(
+        CategoryID id
+) {
+    public static CreateCategoryOutput from(
+            final Category aCategory
+    ) {
+        return new CreateCategoryOutput(aCategory.getId());
+    }
+}

--- a/application/src/main/java/com/sollaris/admin/catalogo/application/category/create/CreateCategoryUseCase.java
+++ b/application/src/main/java/com/sollaris/admin/catalogo/application/category/create/CreateCategoryUseCase.java
@@ -1,0 +1,7 @@
+package com.sollaris.admin.catalogo.application.category.create;
+
+import com.sollaris.admin.catalogo.application.UseCase;
+
+public abstract class CreateCategoryUseCase extends UseCase<CreateCategoryCommand, CreateCategoryOutput> {
+
+}

--- a/application/src/main/java/com/sollaris/admin/catalogo/application/category/create/DefaultCreateCategoryUseCase.java
+++ b/application/src/main/java/com/sollaris/admin/catalogo/application/category/create/DefaultCreateCategoryUseCase.java
@@ -1,0 +1,28 @@
+package com.sollaris.admin.catalogo.application.category.create;
+
+import com.sollaris.admin.catalogo.domain.category.Category;
+import com.sollaris.admin.catalogo.domain.category.CategoryGateway;
+import com.sollaris.admin.catalogo.domain.validation.handler.ThrowsValidationsHandler;
+
+import java.util.Objects;
+
+public class DefaultCreateCategoryUseCase extends CreateCategoryUseCase{
+
+    private final CategoryGateway categoryGateway;
+
+    public DefaultCreateCategoryUseCase(CategoryGateway categoryGateway) {
+        this.categoryGateway = Objects.requireNonNull(categoryGateway);
+    }
+
+    @Override
+    public CreateCategoryOutput execute(final CreateCategoryCommand aCommand) {
+        final var aName = aCommand.name();
+        final var aDescription = aCommand.description();
+        final var aIsActive = aCommand.isActive();
+
+        final var aCategory = Category.newCategory(aName, aDescription, aIsActive);
+        aCategory.validate(new ThrowsValidationsHandler());
+
+        return CreateCategoryOutput.from(this.categoryGateway.create(aCategory));
+    }
+}

--- a/application/src/test/java/com/sollaris/admin/catalogo/application/UseCaseTest.java
+++ b/application/src/test/java/com/sollaris/admin/catalogo/application/UseCaseTest.java
@@ -2,11 +2,13 @@ package com.sollaris.admin.catalogo.application;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+@ExtendWith(MockitoExtension.class)
 public class UseCaseTest {
     @Test
     public void testCreateUseCase() {
-        Assertions.assertNotNull(new UseCase());
-        Assertions.assertNotNull(new UseCase().execute());
+
     }
 }

--- a/application/src/test/java/com/sollaris/admin/catalogo/application/category/create/CreateCategoryUseCaseTest.java
+++ b/application/src/test/java/com/sollaris/admin/catalogo/application/category/create/CreateCategoryUseCaseTest.java
@@ -1,0 +1,57 @@
+package com.sollaris.admin.catalogo.application.category.create;
+
+import com.sollaris.admin.catalogo.domain.category.Category;
+import com.sollaris.admin.catalogo.domain.category.CategoryGateway;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Objects;
+
+import static org.mockito.AdditionalAnswers.returnsFirstArg;
+
+public class CreateCategoryUseCaseTest {
+    @Test
+    public void givenAValidCommand_whenCallsCreateCategory_shouldReturnCategoryId() {
+        final var expectedName = "Movies";
+        final var expectedDescription = "Movies category";
+        final var expectedIsActive = true;
+        final var expectedCategory = Category.newCategory(
+            expectedName,
+            expectedDescription,
+            expectedIsActive
+        );
+
+        final var aCommand = CreateCategoryCommand.with(
+            expectedName,
+            expectedDescription,
+            expectedIsActive
+        );
+
+        final CategoryGateway categoryGateway = Mockito.mock(CategoryGateway.class);
+
+        Mockito.when(categoryGateway.create(Mockito.any()))
+                .thenAnswer(returnsFirstArg());
+
+        final var useCase = new DefaultCreateCategoryUseCase(categoryGateway);
+
+        final var actualOutput = useCase.execute(aCommand);
+
+        Assertions.assertNotNull(actualOutput);
+        Assertions.assertNotNull(actualOutput.id());
+
+        Mockito.verify(categoryGateway, Mockito.times(1))
+                .create(Mockito.argThat(aCategory -> {
+                    return Objects.equals(expectedName, aCategory.getName())
+                        && Objects.equals(expectedDescription, aCategory.getDescription())
+                        && Objects.equals(expectedIsActive, aCategory.isActive())
+                            && Objects.nonNull(aCategory.getId())
+                            && Objects.nonNull(aCategory.getCreatedAt())
+                            && Objects.nonNull(aCategory.getUpdatedAt())
+                            && Objects.isNull(aCategory.getDeletedAt());
+                }
+
+        ));
+
+    }
+}

--- a/domain/src/main/java/com/sollaris/admin/catalogo/domain/category/CategoryGateway.java
+++ b/domain/src/main/java/com/sollaris/admin/catalogo/domain/category/CategoryGateway.java
@@ -1,0 +1,17 @@
+package com.sollaris.admin.catalogo.domain.category;
+
+import com.sollaris.admin.catalogo.domain.pagination.Pagination;
+
+import java.util.Optional;
+
+public interface CategoryGateway {
+    Category create(Category aCategory);
+
+    void deleteById(CategoryID anId);
+
+    Optional<Category> findById(CategoryID anId);
+
+    Category update(Category aCategory);
+
+    Pagination<Category> findAll(CategorySearchQuery aQuery);
+}

--- a/domain/src/main/java/com/sollaris/admin/catalogo/domain/category/CategorySearchQuery.java
+++ b/domain/src/main/java/com/sollaris/admin/catalogo/domain/category/CategorySearchQuery.java
@@ -1,0 +1,10 @@
+package com.sollaris.admin.catalogo.domain.category;
+
+public record CategorySearchQuery(
+        int page,
+        int perPage,
+        String terms,
+        String sort,
+        String direction
+) {
+}

--- a/domain/src/main/java/com/sollaris/admin/catalogo/domain/pagination/Pagination.java
+++ b/domain/src/main/java/com/sollaris/admin/catalogo/domain/pagination/Pagination.java
@@ -1,0 +1,12 @@
+package com.sollaris.admin.catalogo.domain.pagination;
+
+import java.util.List;
+
+public record Pagination<T>(
+        int currentPage,
+        int perPage,
+        long total,
+        List<T> items
+) {
+
+}


### PR DESCRIPTION
## Summary by Sourcery

Introduce a generic UseCase abstraction and implement the CreateCategory use case with supporting domain interfaces and pagination.

New Features:
- Add generic UseCase<IN, OUT>, NullaryUseCase, and UnitUseCase base classes
- Define CreateCategoryCommand and CreateCategoryOutput records and abstract CreateCategoryUseCase
- Implement DefaultCreateCategoryUseCase with validation and external CategoryGateway
- Introduce CategoryGateway interface and domain pagination support (Pagination and CategorySearchQuery)

Build:
- Add Mockito JUnit Jupiter dependency for unit testing

Tests:
- Add CreateCategoryUseCaseTest to verify category creation and gateway interaction
- Enable Mockito in UseCaseTest scaffold and update test dependencies