### PR TITLE
Added notification class and instaled vavr

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -11,6 +11,7 @@ repositories {
 
 dependencies {
     implementation(project(":domain"))
+    implementation "io.vavr:vavr:0.10.4"
     testImplementation platform('org.junit:junit-bom:5.10.0')
     testImplementation "org.mockito:mockito-junit-jupiter:5.18.0"
     testImplementation 'org.junit.jupiter:junit-jupiter'

--- a/application/src/main/java/com/sollaris/admin/catalogo/application/category/create/CreateCategoryUseCase.java
+++ b/application/src/main/java/com/sollaris/admin/catalogo/application/category/create/CreateCategoryUseCase.java
@@ -1,7 +1,9 @@
 package com.sollaris.admin.catalogo.application.category.create;
 
 import com.sollaris.admin.catalogo.application.UseCase;
+import com.sollaris.admin.catalogo.domain.validation.handler.Notification;
+import io.vavr.control.Either;
 
-public abstract class CreateCategoryUseCase extends UseCase<CreateCategoryCommand, CreateCategoryOutput> {
+public abstract class CreateCategoryUseCase extends UseCase<CreateCategoryCommand, Either<Notification, CreateCategoryOutput>> {
 
 }

--- a/application/src/main/java/com/sollaris/admin/catalogo/application/category/create/DefaultCreateCategoryUseCase.java
+++ b/application/src/main/java/com/sollaris/admin/catalogo/application/category/create/DefaultCreateCategoryUseCase.java
@@ -2,7 +2,9 @@ package com.sollaris.admin.catalogo.application.category.create;
 
 import com.sollaris.admin.catalogo.domain.category.Category;
 import com.sollaris.admin.catalogo.domain.category.CategoryGateway;
+import com.sollaris.admin.catalogo.domain.validation.handler.Notification;
 import com.sollaris.admin.catalogo.domain.validation.handler.ThrowsValidationsHandler;
+import io.vavr.control.Either;
 
 import java.util.Objects;
 
@@ -15,13 +17,19 @@ public class DefaultCreateCategoryUseCase extends CreateCategoryUseCase{
     }
 
     @Override
-    public CreateCategoryOutput execute(final CreateCategoryCommand aCommand) {
+    public Either<Notification, CreateCategoryOutput> execute(final CreateCategoryCommand aCommand) {
         final var aName = aCommand.name();
         final var aDescription = aCommand.description();
         final var aIsActive = aCommand.isActive();
 
+        final var notification = Notification.create();
+
         final var aCategory = Category.newCategory(aName, aDescription, aIsActive);
-        aCategory.validate(new ThrowsValidationsHandler());
+        aCategory.validate(notification);
+
+        if (notification.hasErrors()) {
+
+        }
 
         return CreateCategoryOutput.from(this.categoryGateway.create(aCategory));
     }

--- a/application/src/test/java/com/sollaris/admin/catalogo/application/category/create/CreateCategoryUseCaseTest.java
+++ b/application/src/test/java/com/sollaris/admin/catalogo/application/category/create/CreateCategoryUseCaseTest.java
@@ -3,14 +3,36 @@ package com.sollaris.admin.catalogo.application.category.create;
 import com.sollaris.admin.catalogo.domain.category.Category;
 import com.sollaris.admin.catalogo.domain.category.CategoryGateway;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Objects;
 
 import static org.mockito.AdditionalAnswers.returnsFirstArg;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 public class CreateCategoryUseCaseTest {
+
+    @InjectMocks
+    private DefaultCreateCategoryUseCase useCase;
+
+    @Mock
+    private CategoryGateway categoryGateway;
+
+    @BeforeEach
+    void cleanUp() {
+        Mockito.reset(categoryGateway);
+    }
+
     @Test
     public void givenAValidCommand_whenCallsCreateCategory_shouldReturnCategoryId() {
         final var expectedName = "Movies";
@@ -30,7 +52,7 @@ public class CreateCategoryUseCaseTest {
 
         final CategoryGateway categoryGateway = Mockito.mock(CategoryGateway.class);
 
-        Mockito.when(categoryGateway.create(Mockito.any()))
+        when(categoryGateway.create(any()))
                 .thenAnswer(returnsFirstArg());
 
         final var useCase = new DefaultCreateCategoryUseCase(categoryGateway);
@@ -40,8 +62,8 @@ public class CreateCategoryUseCaseTest {
         Assertions.assertNotNull(actualOutput);
         Assertions.assertNotNull(actualOutput.id());
 
-        Mockito.verify(categoryGateway, Mockito.times(1))
-                .create(Mockito.argThat(aCategory -> {
+        Mockito.verify(categoryGateway, times(1))
+                .create(argThat(aCategory -> {
                     return Objects.equals(expectedName, aCategory.getName())
                         && Objects.equals(expectedDescription, aCategory.getDescription())
                         && Objects.equals(expectedIsActive, aCategory.isActive())
@@ -54,4 +76,82 @@ public class CreateCategoryUseCaseTest {
         ));
 
     }
+
+    @Test
+    public void givenAInvalidName_whenCallsCreateCategory_thenShouldReturnDomainException() {
+        final String expectedName = null;
+        final var expectedDescription = "A categoria mais assistida";
+        final var expectedIsActive = true;
+        final var expectedErrorMessage = "'name' should not be null";
+        final var expectedErrorCount = 1;
+
+        final var aCommand =
+                CreateCategoryCommand.with(expectedName, expectedDescription, expectedIsActive);
+
+        final var notification = useCase.execute(aCommand).getLeft();
+
+        Assertions.assertEquals(expectedErrorCount, notification.getErrors().size());
+        Assertions.assertEquals(expectedErrorMessage, notification.firstError().message());
+
+        Mockito.verify(categoryGateway, times(0)).create(any());
+    }
+
+    @Test
+    public void givenAValidCommandWithInactiveCategory_whenCallsCreateCategory_shouldReturnInactiveCategoryId() {
+        final var expectedName = "Filmes";
+        final var expectedDescription = "A categoria mais assistida";
+        final var expectedIsActive = false;
+
+        final var aCommand =
+                CreateCategoryCommand.with(expectedName, expectedDescription, expectedIsActive);
+
+        when(categoryGateway.create(any()))
+                .thenAnswer(returnsFirstArg());
+
+        final var actualOutput = useCase.execute(aCommand).get();
+
+        Assertions.assertNotNull(actualOutput);
+        Assertions.assertNotNull(actualOutput.id());
+
+        Mockito.verify(categoryGateway, times(1)).create(argThat(aCategory ->
+                Objects.equals(expectedName, aCategory.getName())
+                        && Objects.equals(expectedDescription, aCategory.getDescription())
+                        && Objects.equals(expectedIsActive, aCategory.isActive())
+                        && Objects.nonNull(aCategory.getId())
+                        && Objects.nonNull(aCategory.getCreatedAt())
+                        && Objects.nonNull(aCategory.getUpdatedAt())
+                        && Objects.nonNull(aCategory.getDeletedAt())
+        ));
+    }
+
+    @Test
+    public void givenAValidCommand_whenGatewayThrowsRandomException_shouldReturnAException() {
+        final var expectedName = "Filmes";
+        final var expectedDescription = "A categoria mais assistida";
+        final var expectedIsActive = true;
+        final var expectedErrorCount = 1;
+        final var expectedErrorMessage = "Gateway error";
+
+        final var aCommand =
+                CreateCategoryCommand.with(expectedName, expectedDescription, expectedIsActive);
+
+        when(categoryGateway.create(any()))
+                .thenThrow(new IllegalStateException(expectedErrorMessage));
+
+        final var notification = useCase.execute(aCommand).getLeft();
+
+        Assertions.assertEquals(expectedErrorCount, notification.getErrors().size());
+        Assertions.assertEquals(expectedErrorMessage, notification.firstError().message());
+
+        Mockito.verify(categoryGateway, times(1)).create(argThat(aCategory ->
+                Objects.equals(expectedName, aCategory.getName())
+                        && Objects.equals(expectedDescription, aCategory.getDescription())
+                        && Objects.equals(expectedIsActive, aCategory.isActive())
+                        && Objects.nonNull(aCategory.getId())
+                        && Objects.nonNull(aCategory.getCreatedAt())
+                        && Objects.nonNull(aCategory.getUpdatedAt())
+                        && Objects.isNull(aCategory.getDeletedAt())
+        ));
+    }
+
 }

--- a/domain/src/main/java/com/sollaris/admin/catalogo/domain/validation/handler/Notification.java
+++ b/domain/src/main/java/com/sollaris/admin/catalogo/domain/validation/handler/Notification.java
@@ -1,0 +1,54 @@
+package com.sollaris.admin.catalogo.domain.validation.handler;
+
+import com.sollaris.admin.catalogo.domain.exceptions.DomainException;
+import com.sollaris.admin.catalogo.domain.validation.Error;
+import com.sollaris.admin.catalogo.domain.validation.ValidationHandler;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Notification implements ValidationHandler {
+
+    private final List<Error> erros;
+
+    private Notification(final List<Error> errors) {
+        this.erros = errors;
+    }
+
+    public static Notification create() {
+        return new Notification(new ArrayList<>());
+    }
+
+    public static Notification create(final Error anError) {
+        return new Notification(new ArrayList<>()).append(anError);
+    }
+
+    @Override
+    public Notification append(final Error anError) {
+        this.erros.add(anError);
+        return this;
+    }
+
+    @Override
+    public Notification append(final ValidationHandler anError) {
+        this.erros.addAll(anError.getErrors());
+        return this;
+    }
+
+    @Override
+    public Notification validate(final Validation aValidation) {
+        try {
+            aValidation.validate();
+        } catch (final DomainException ex) {
+            this.erros.addAll(ex.getErrors());
+        } catch (final Throwable t) {
+            this.erros.add(new Error(t.getMessage()));
+        }
+        return this;
+    }
+
+    @Override
+    public List<Error> getErrors() {
+        return this.erros;
+    }
+}


### PR DESCRIPTION
## Summary by Sourcery

Implement a notification-based validation handler and switch create-category use case to return a Vavr Either, updating tests and adding new validation and error-handling test scenarios

New Features:
- Add Notification class for accumulating validation errors
- Return Either<Notification,CreateCategoryOutput> from CreateCategoryUseCase
- Introduce Vavr library for functional Either type

Enhancements:
- Refactor CreateCategoryUseCase tests to use MockitoExtension with @Mock and @InjectMocks
- Add test cases for invalid input validation, inactive category creation, and gateway exception handling

Build:
- Add Vavr dependency to application build.gradle