### PR TITLE
Added notification class and instaled vavr

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -11,7 +11,7 @@ repositories {
 
 dependencies {
     implementation(project(":domain"))
-    implementation "io.vavr:vavr:0.10.4"
+    implementation 'io.vavr:vavr:0.10.4'
     testImplementation platform('org.junit:junit-bom:5.10.0')
     testImplementation "org.mockito:mockito-junit-jupiter:5.18.0"
     testImplementation 'org.junit.jupiter:junit-jupiter'

--- a/application/src/main/java/com/sollaris/admin/catalogo/application/UnitUseCase.java
+++ b/application/src/main/java/com/sollaris/admin/catalogo/application/UnitUseCase.java
@@ -1,5 +1,5 @@
 package com.sollaris.admin.catalogo.application;
 
-public abstract class UnitUseCase {
+public abstract class UnitUseCase<IN> {
     public abstract void execute(IN anIn);
 }

--- a/application/src/main/java/com/sollaris/admin/catalogo/application/category/create/DefaultCreateCategoryUseCase.java
+++ b/application/src/main/java/com/sollaris/admin/catalogo/application/category/create/DefaultCreateCategoryUseCase.java
@@ -8,6 +8,9 @@ import io.vavr.control.Either;
 
 import java.util.Objects;
 
+import static io.vavr.API.Left;
+import static io.vavr.API.Try;
+
 public class DefaultCreateCategoryUseCase extends CreateCategoryUseCase{
 
     private final CategoryGateway categoryGateway;
@@ -27,10 +30,12 @@ public class DefaultCreateCategoryUseCase extends CreateCategoryUseCase{
         final var aCategory = Category.newCategory(aName, aDescription, aIsActive);
         aCategory.validate(notification);
 
-        if (notification.hasErrors()) {
+        return notification.hasErrors() ? Left(notification) : create(aCategory);
+    }
 
-        }
-
-        return CreateCategoryOutput.from(this.categoryGateway.create(aCategory));
+    private Either<Notification, CreateCategoryOutput> create(final Category aCategory) {
+        return Try(() -> this.categoryGateway.create(aCategory))
+                .toEither()
+                .bimap(Notification::create, CreateCategoryOutput::from);
     }
 }

--- a/application/src/test/java/com/sollaris/admin/catalogo/application/category/create/CreateCategoryUseCaseTest.java
+++ b/application/src/test/java/com/sollaris/admin/catalogo/application/category/create/CreateCategoryUseCaseTest.java
@@ -60,7 +60,7 @@ public class CreateCategoryUseCaseTest {
         final var actualOutput = useCase.execute(aCommand);
 
         Assertions.assertNotNull(actualOutput);
-        Assertions.assertNotNull(actualOutput.id());
+        Assertions.assertNotNull(actualOutput.get().id());
 
         Mockito.verify(categoryGateway, times(1))
                 .create(argThat(aCategory -> {
@@ -89,6 +89,7 @@ public class CreateCategoryUseCaseTest {
                 CreateCategoryCommand.with(expectedName, expectedDescription, expectedIsActive);
 
         final var notification = useCase.execute(aCommand).getLeft();
+
 
         Assertions.assertEquals(expectedErrorCount, notification.getErrors().size());
         Assertions.assertEquals(expectedErrorMessage, notification.firstError().message());

--- a/domain/src/main/java/com/sollaris/admin/catalogo/domain/validation/ValidationHandler.java
+++ b/domain/src/main/java/com/sollaris/admin/catalogo/domain/validation/ValidationHandler.java
@@ -12,6 +12,15 @@ public interface ValidationHandler {
         return getErrors() != null && !(getErrors().isEmpty());
     }
 
+    default Error firstError() {
+        if (getErrors() != null && !getErrors().isEmpty()) {
+            return getErrors().get(0);
+        }
+        else {
+            return null;
+        }
+     }
+
     public interface Validation {
         void validate();
     }

--- a/domain/src/main/java/com/sollaris/admin/catalogo/domain/validation/handler/Notification.java
+++ b/domain/src/main/java/com/sollaris/admin/catalogo/domain/validation/handler/Notification.java
@@ -23,6 +23,10 @@ public class Notification implements ValidationHandler {
         return new Notification(new ArrayList<>()).append(anError);
     }
 
+    public static Notification create(final Throwable t) {
+        return create(new Error(t.getMessage()));
+    }
+
     @Override
     public Notification append(final Error anError) {
         this.erros.add(anError);


### PR DESCRIPTION
## Summary by Sourcery

Introduce functional error handling with Vavr's Either and Try in the create category use case, extend domain validation helpers, adapt tests to the new flow, and make the base use case interface generic.

New Features:
- Handle repository exceptions in DefaultCreateCategoryUseCase using Vavr's Try-to-Either conversion

Enhancements:
- Refactor DefaultCreateCategoryUseCase to return Either<Notification, CreateCategoryOutput> with Left for errors
- Add firstError() helper to ValidationHandler and Throwable overload to Notification

Build:
- Include Vavr dependency in application build.gradle

Tests:
- Update CreateCategoryUseCaseTest to work with Either API and new notification helpers

Chores:
- Make UnitUseCase interface generic